### PR TITLE
API conrollers: Post - Get

### DIFF
--- a/Controllers/V1/Pets/PetDeleteController.cs
+++ b/Controllers/V1/Pets/PetDeleteController.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+
+namespace VetCare_BackEnd.Controllers.V1.Pets
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class PetDeleteController : ControllerBase
+    {
+        
+    }
+}

--- a/Controllers/V1/Pets/PetGetController.cs
+++ b/Controllers/V1/Pets/PetGetController.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using VetCare_BackEnd.Data;
 
 namespace VetCare_BackEnd.Controllers.V1.Pets
 {
@@ -10,6 +12,37 @@ namespace VetCare_BackEnd.Controllers.V1.Pets
     [Route("api/[controller]")]
     public class PetGetController : ControllerBase
     {
-        
+        private readonly ApplicationDbContext _context;
+
+        public PetGetController(ApplicationDbContext context)
+        {
+            _context = context;
+        }
+
+        [HttpGet("allPets")]
+        public async Task<IActionResult> AllPets()
+        {
+            var result = await _context.Pets.ToListAsync();
+
+            if (result.Count == 0)
+            {
+                return NotFound("The table 'Pets' is empty");
+            }
+
+            return Ok(result);
+        }
+
+        [HttpGet("petById/{id}")]
+        public async Task<IActionResult> PetById(int id)
+        {
+            var result = await _context.Pets.FirstOrDefaultAsync(p => p.Id == id);
+
+            if (result == null)
+            {
+                return NotFound("Id Not Found");
+            }
+
+            return Ok(result);
+        }
     }
 }

--- a/Controllers/V1/Pets/PetPostController.cs
+++ b/Controllers/V1/Pets/PetPostController.cs
@@ -3,6 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using VetCare_BackEnd.Data;
+using VetCare_BackEnd.Models;
 
 namespace VetCare_BackEnd.Controllers.V1.Pets
 {
@@ -10,6 +13,52 @@ namespace VetCare_BackEnd.Controllers.V1.Pets
     [Route("api/[controller]")]
     public class PetPostController : ControllerBase
     {
-        
+        private readonly ApplicationDbContext _context;
+        public PetPostController(ApplicationDbContext context)
+        {
+            _context = context;
+        }
+
+        [HttpPost("CreatePet")]
+        public async Task<IActionResult> CreatePet([FromBody] PetDTO _petDTO)
+        {
+            if (_petDTO == null)
+            {
+                return BadRequest("Pet data is null");
+            }
+
+            else if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            var user = await _context.Users.FirstOrDefaultAsync(u => u.Id == _petDTO.user_id);
+
+            if (user == null)
+            {
+                return NotFound("An user by that Id doesnt exist");
+            }
+
+            if (_petDTO.BirthDate.Year > DateTime.Now.Year)
+            {
+                return BadRequest("We have not yet reached the target date");
+            }
+
+            var pet = new Pet
+            {
+                Name = _petDTO.Name.ToLower(),
+                Breed = _petDTO.Breed.ToLower(),
+                Weight = _petDTO.Weight.ToUpper(),
+                BirthDate = _petDTO.BirthDate,
+                Sex = _petDTO.Sex.ToLower(),
+                user_id = _petDTO.user_id,
+                User = user
+            };
+
+            _context.Pets.Add(pet);
+            await _context.SaveChangesAsync();
+
+            return Created();
+        }
     }
 }

--- a/Models/Appointment.cs
+++ b/Models/Appointment.cs
@@ -11,6 +11,7 @@ namespace VetCare_BackEnd.Models
     public class Appointment
     {
         [Key]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
         public int Id { get; set; }
 
         [Required]

--- a/Models/AppointmentType.cs
+++ b/Models/AppointmentType.cs
@@ -11,6 +11,7 @@ namespace VetCare_BackEnd.Models
     public class AppointmentType
     {
         [Key]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
         public int Id { get; set; }
         
         [Required]

--- a/Models/DateOnlyConverter.cs
+++ b/Models/DateOnlyConverter.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+
+namespace VetCare_BackEnd.Models
+{
+    public class DateOnlyConverter : JsonConverter<DateOnly>
+    {
+        private const string DateFormat = "yyyy-MM-dd";
+
+    public override DateOnly Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        return DateOnly.ParseExact(reader.GetString()!, DateFormat);
+    }
+
+    public override void Write(Utf8JsonWriter writer, DateOnly value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value.ToString(DateFormat));
+    }
+    }
+}

--- a/Models/DocumentType.cs
+++ b/Models/DocumentType.cs
@@ -11,6 +11,7 @@ namespace VetCare_BackEnd.Models
     public class DocumentType
     {
         [Key]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
         public int Id { get; set; }
 
         [Required]

--- a/Models/Pet.cs
+++ b/Models/Pet.cs
@@ -29,6 +29,8 @@ namespace VetCare_BackEnd.Models
 
         [Required]
         [DataType(DataType.Date)]
+        [RegularExpression(@"^\d{4}-\d{2}-\d{2}$", ErrorMessage = "The input format should be like: yyyy-MM-dd.")]
+        [StringLength(10, MinimumLength = 10, ErrorMessage = "The Date should have exactly 10 characters.")]  //regular expresion for the date yyyy-MM-dd
         public DateOnly BirthDate { get; set; }
 
         [Required]

--- a/Models/Pet.cs
+++ b/Models/Pet.cs
@@ -11,6 +11,7 @@ namespace VetCare_BackEnd.Models
     public class Pet
     {
         [Key]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
         public int Id { get; set; }
 
 
@@ -39,6 +40,6 @@ namespace VetCare_BackEnd.Models
 
         // Navigation properties
         [ForeignKey("user_id")]
-        public required User User { get; set; }
+        public User? User { get; set; }
     }
 }

--- a/Models/Pet.cs
+++ b/Models/Pet.cs
@@ -35,10 +35,10 @@ namespace VetCare_BackEnd.Models
         public required string Sex { get; set; }
 
         // Foreign keys
-        public int UserId { get; set; }
+        public int user_id { get; set; }
 
         // Navigation properties
-        [ForeignKey("UserId")]
+        [ForeignKey("user_id")]
         public required User User { get; set; }
     }
 }

--- a/Models/PetDTO.cs
+++ b/Models/PetDTO.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace VetCare_BackEnd.Models
+{
+    public class PetDTO
+    {
+    public required string Name { get; set; }
+    public required string Breed { get; set; }
+    public required string Weight { get; set; }
+    public required DateOnly BirthDate { get; set; }
+    public required string Sex { get; set; }
+    public required int user_id { get; set; }
+    }
+}

--- a/Models/Role.cs
+++ b/Models/Role.cs
@@ -11,6 +11,7 @@ namespace VetCare_BackEnd.Models
     public class Role
     {
         [Key]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
         public int Id { get; set; }
 
         [Required]

--- a/Models/User.cs
+++ b/Models/User.cs
@@ -11,6 +11,7 @@ namespace VetCare_BackEnd.Models
     public class User
     {
         [Key]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
         public int Id { get; set; }
 
         [Required]

--- a/Models/User.cs
+++ b/Models/User.cs
@@ -27,6 +27,8 @@ namespace VetCare_BackEnd.Models
 
         
         [DataType(DataType.Date)]
+        [RegularExpression(@"^\d{4}-\d{2}-\d{2}$", ErrorMessage = "The input format should be like: yyyy-MM-dd.")]
+        [StringLength(10, MinimumLength = 10, ErrorMessage = "The Date should have exactly 10 characters.")]  //regular expresion for the date yyyy-MM-dd
         public DateOnly? BirthDate { get; set; }
 
         [Required]

--- a/Program.cs
+++ b/Program.cs
@@ -1,6 +1,7 @@
 using DotNetEnv;
 using Microsoft.EntityFrameworkCore;
 using VetCare_BackEnd.Data;
+using VetCare_BackEnd.Models;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -14,6 +15,12 @@ var dbPassword = Environment.GetEnvironmentVariable("DB_PASSWORD");
 var conectionDB = $"server={dbHost};port={dbPort};database={dbDatabaseName};uid={dbUser};password={dbPassword}";
 builder.Services.AddDbContext<ApplicationDbContext>(options =>
     options.UseMySql(conectionDB, ServerVersion.Parse("8.0.20-mysql")));
+
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new DateOnlyConverter());
+    });
 
 builder.Services.AddControllers();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle


### PR DESCRIPTION
The changes that were made were around the creation of the API controllers providing methods such as Get and Post, also a configuration was created to read the string format and parse it to DateOnly type, also created the PetDTO class to send it as an argument in the post method.

Some little changes:
- Data Annotations for regular expressions
- Data Annotations auto incrementing primary keys

API Controller
![Captura desde 2024-09-06 09-49-56](https://github.com/user-attachments/assets/76d6dc42-2966-40b3-bf51-ae0bdf22638a)

DateOnly Parse:
![Captura desde 2024-09-06 09-50-35](https://github.com/user-attachments/assets/95a6480e-5ba7-4ef0-8a83-80327b96a323)

DTO:
![Captura desde 2024-09-06 09-52-00](https://github.com/user-attachments/assets/768ae60a-58ab-4d14-a4b4-7d6e299e9e04)
